### PR TITLE
Windows VSCpde: always use "Command Prompt" for terminal activate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
     "idf.portWin": "COM14",
     "idf.adapterTargetName": "esp32s3",
     "idf.openOcdConfigs": [

--- a/activate.bat
+++ b/activate.bat
@@ -1,0 +1,1 @@
+C:\Windows\system32\cmd.exe /k ""C:\Espressif\idf_cmd_init.bat" esp-idf-121ffdbe0b35e1365bcc6c7122ca4a7a"


### PR DESCRIPTION
VSCode defaulted to `PowerShell`. This keeps it at the standard `cmd` which is used in the `idf.py` documentation and makes development easier.